### PR TITLE
Add deploy flows and comprehensive tests

### DIFF
--- a/script/DAOProposalFlow.s.sol
+++ b/script/DAOProposalFlow.s.sol
@@ -6,19 +6,21 @@ import {AlpyDAO} from "../src/AlpyDAO.sol";
 
 contract DAOProposalFlow is Script {
     function run() external {
-        uint256 privateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(privateKey);
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address daoAddr = vm.envAddress("DAO_ADDRESS");
+        address stakingAddr = vm.envAddress("STAKING_ADDRESS");
+        address reviewer = vm.envAddress("REVIEWER");
 
-        AlpyDAO dao = AlpyDAO(0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0);
+        vm.startBroadcast(pk);
 
-        dao.propose(
-            0x0000000000000000000000000000000000000001,
-            0,
-            abi.encodeWithSignature("doSomething()"),
-            "Execute doSomething"
+        AlpyDAO dao = AlpyDAO(daoAddr);
+
+        uint256 id = dao.propose(
+            stakingAddr, 0, abi.encodeWithSignature("setReviewer(address,bool)", reviewer, true), "add reviewer"
         );
 
-        dao.vote(0, true);
+        dao.vote(id, true);
+        dao.execute(id);
 
         vm.stopBroadcast();
     }

--- a/script/LendingFlow.s.sol
+++ b/script/LendingFlow.s.sol
@@ -7,17 +7,22 @@ import {LendingPool} from "../src/LendingPool.sol";
 
 contract LendingFlow is Script {
     function run() external {
-        uint256 privateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(privateKey);
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address poolAddr = vm.envAddress("POOL_ADDRESS");
+        address tokenAddr = vm.envAddress("TOKEN_ADDRESS");
+        address user = vm.addr(pk);
 
-        IERC20 token = IERC20(0x5FbDB2315678afecb367f032d93F642f64180aa3);
-        LendingPool pool = LendingPool(
-            0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-        );
+        vm.startBroadcast(pk);
 
-        token.approve(address(pool), 1_000 ether);
+        LendingPool pool = LendingPool(poolAddr);
+        IERC20 token = IERC20(tokenAddr);
+
         token.approve(address(pool), 1_000 ether);
         pool.supply(token, 1_000 ether);
+        pool.borrow(token, 500 ether);
+        token.approve(address(pool), 500 ether);
+        pool.repay(token, 500 ether, user);
+        pool.withdraw(token, 1_000 ether, user);
 
         vm.stopBroadcast();
     }

--- a/script/LiquidationFlow.s.sol
+++ b/script/LiquidationFlow.s.sol
@@ -2,37 +2,21 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Script.sol";
-import "forge-std/console2.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {LendingPool} from "../src/LendingPool.sol";
-import {MockERC20} from "lib/chainlink-brownie-contracts/contracts/src/v0.8/vendor/forge-std/src/mocks/MockERC20.sol";
-import {AlpyToken} from "src/AlpyToken.sol";
 
 contract LiquidationFlow is Script {
     function run() external {
         uint256 pk = vm.envUint("PRIVATE_KEY");
-        address user = vm.addr(pk);
+        address poolAddr = vm.envAddress("POOL_ADDRESS");
+        address collateral = vm.envAddress("COLLATERAL_TOKEN");
+        address borrower = vm.envAddress("BORROWER");
+        uint256 repayAmount = vm.envUint("REPAY_AMOUNT");
+
         vm.startBroadcast(pk);
 
-        console.log("---- Liquidation Debug ----");
-
-        AlpyToken alpy = AlpyToken(0x5FbDB2315678afecb367f032d93F642f64180aa3); // Collateral
-        MockERC20 debtToken = MockERC20(
-            0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
-        ); // Debt token with mint()
-        LendingPool pool = LendingPool(
-            0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
-        );
-
-        alpy.approve(address(pool), 100 ether);
-        pool.supply(address(alpy), 100 ether);
-
-        debtToken.mint(user, 100 ether);
-        debtToken.approve(address(pool), 100 ether);
-        pool.borrow(address(debtToken), 100 ether);
-
-        // Optional: Simulate price change here via oracle (if needed)
-
-        pool.liquidate(address(alpy), user, 100 ether);
+        LendingPool pool = LendingPool(poolAddr);
+        pool.liquidate(IERC20(collateral), borrower, repayAmount);
 
         vm.stopBroadcast();
     }

--- a/script/RewardClaim.s.sol
+++ b/script/RewardClaim.s.sol
@@ -1,29 +1,18 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
 import "forge-std/Script.sol";
-import "forge-std/console2.sol";
-import {LendingPool} from "../src/LendingPool.sol";
-import {IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {RewardDistributor} from "../src/RewardDistributor.sol";
 
-contract LiquidationFlow is Script {
+contract RewardClaim is Script {
     function run() external {
-        uint256 privateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(privateKey);
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address distributorAddr = vm.envAddress("DISTRIBUTOR_ADDRESS");
 
-        LendingPool pool = LendingPool(
-            0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
-        );
-        IERC20 token = IERC20(0x5FbDB2315678afecb367f032d93F642f64180aa3);
-        address user = 0xAb8483F64d9C6d1EcF9b849Ae677dD3315835cb2;
-        uint256 repayAmount = 100 * 1e18;
+        vm.startBroadcast(pk);
 
-        console2.log("Debt:", pool.debt(user, address(token)));
-        console2.log("Collateral:", pool.collateral(user, address(token)));
-        console2.log("Debt USD:", pool.getDebtValueUSD(user));
-        console2.log("Collateral USD:", pool.getCollateralValueUSD(user));
-        console2.log("LTV:", pool.getLTV());
-
-        pool.liquidate(token, user, repayAmount);
+        RewardDistributor distributor = RewardDistributor(distributorAddr);
+        distributor.claim();
 
         vm.stopBroadcast();
     }

--- a/script/StakingFlow.s.sol
+++ b/script/StakingFlow.s.sol
@@ -7,17 +7,18 @@ import {AlpyStaking} from "../src/AlpyStaking.sol";
 
 contract StakingFlow is Script {
     function run() external {
-        uint256 privateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(privateKey);
+        uint256 pk = vm.envUint("PRIVATE_KEY");
+        address tokenAddr = vm.envAddress("TOKEN_ADDRESS");
+        address stakingAddr = vm.envAddress("STAKING_ADDRESS");
+        vm.startBroadcast(pk);
 
-        IERC20 token = IERC20(0x5FbDB2315678afecb367f032d93F642f64180aa3);
-        AlpyStaking staking = AlpyStaking(
-            0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
-        );
+        IERC20 token = IERC20(tokenAddr);
+        AlpyStaking staking = AlpyStaking(stakingAddr);
 
         token.approve(address(staking), 1_000 ether);
         staking.stake(1_000 ether, 10 days);
         staking.extendLock(20 days);
+        vm.warp(block.timestamp + 20 days + 1);
         staking.withdraw();
 
         vm.stopBroadcast();

--- a/src/AlpyStaking.sol
+++ b/src/AlpyStaking.sol
@@ -28,12 +28,7 @@ contract AlpyStaking is Ownable {
     uint256 public constant SLASH_PERCENT_NO_STAKE = 20;
     uint256 public constant COOLDOWN = 5 minutes;
 
-    event Slashed(
-        address indexed user,
-        uint256 stakeSlashed,
-        uint256 tokenSlashed,
-        uint256 bannedUntil
-    );
+    event Slashed(address indexed user, uint256 stakeSlashed, uint256 tokenSlashed, uint256 bannedUntil);
 
     struct Stake {
         uint256 amount;
@@ -47,26 +42,24 @@ contract AlpyStaking is Ownable {
     mapping(address => uint256) public lastSlashed;
     mapping(address => bool) public isReviewer;
 
-    constructor(
-        address _stakingToken,
-        address _DAO,
-        address _treasury
-    ) Ownable(msg.sender) {
+    constructor(address _stakingToken, address _DAO, address _treasury) Ownable(msg.sender) {
         stakingToken = IERC20(_stakingToken);
         DAO = _DAO;
         treasury = _treasury;
     }
 
     modifier onlyAuthorized() {
-        if (msg.sender != DAO && !isReviewer[msg.sender])
+        if (msg.sender != DAO && !isReviewer[msg.sender]) {
             revert NotAuthorized();
+        }
         _;
     }
 
     function stake(uint256 amount, uint256 duration) external {
         if (amount == 0) revert ZeroAmount();
-        if (duration < MIN_LOCK_DURATION || duration > MAX_LOCK_DURATION)
+        if (duration < MIN_LOCK_DURATION || duration > MAX_LOCK_DURATION) {
             revert InvalidDuration();
+        }
 
         Stake storage s = stakes[msg.sender];
         if (s.amount > 0) revert AlreadyStaked();
@@ -81,8 +74,9 @@ contract AlpyStaking is Ownable {
     function extendLock(uint256 newDuration) external {
         Stake storage s = stakes[msg.sender];
         if (s.amount == 0) revert NoStake();
-        if (newDuration <= s.lockDuration || newDuration > MAX_LOCK_DURATION)
+        if (newDuration <= s.lockDuration || newDuration > MAX_LOCK_DURATION) {
             revert InvalidDuration();
+        }
 
         s.lockDuration = newDuration;
         s.lockEnd = block.timestamp + newDuration;
@@ -103,9 +97,16 @@ contract AlpyStaking is Ownable {
         return s.amount * s.lockDuration;
     }
 
+    function getVotes(address user) external view returns (uint256) {
+        Stake storage s = stakes[user];
+        if (block.timestamp >= s.lockEnd) return 0;
+        return s.amount * s.lockDuration;
+    }
+
     function slash(address user) external onlyAuthorized {
-        if (block.timestamp < lastSlashed[user] + COOLDOWN)
+        if (block.timestamp < lastSlashed[user] + COOLDOWN) {
             revert CooldownActive();
+        }
 
         uint256 stakeAmt = stakes[user].amount;
         uint256 tokenBal = stakingToken.balanceOf(user);
@@ -121,19 +122,8 @@ contract AlpyStaking is Ownable {
         }
 
         if (tokenBal > 0) {
-            tokenSlash =
-                (tokenBal *
-                    (
-                        stakeAmt > 0
-                            ? SLASH_PERCENT_WITH_STAKE
-                            : SLASH_PERCENT_NO_STAKE
-                    )) /
-                100;
-            bool success = stakingToken.transferFrom(
-                user,
-                treasury,
-                tokenSlash
-            );
+            tokenSlash = (tokenBal * (stakeAmt > 0 ? SLASH_PERCENT_WITH_STAKE : SLASH_PERCENT_NO_STAKE)) / 100;
+            bool success = stakingToken.transferFrom(user, treasury, tokenSlash);
             if (!success) revert TransferFailed();
             totalSlashed += tokenSlash;
         }

--- a/test/AlpyDAO.t.sol
+++ b/test/AlpyDAO.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {AlpyToken} from "../src/AlpyToken.sol";
+import {AlpyStaking} from "../src/AlpyStaking.sol";
+import {AlpyDAO} from "../src/AlpyDAO.sol";
+
+contract AlpyDAOTest is Test {
+    AlpyToken token;
+    AlpyStaking staking;
+    AlpyDAO dao;
+    address voter = address(1);
+
+    function setUp() public {
+        token = new AlpyToken();
+        staking = new AlpyStaking(address(token), address(this), address(this));
+        dao = new AlpyDAO(address(staking), 1 days);
+        staking.transferOwnership(address(dao));
+        deal(address(token), voter, 1_000 ether);
+
+        vm.startPrank(voter);
+        token.approve(address(staking), 1_000 ether);
+        staking.stake(1_000 ether, 7 days);
+        vm.stopPrank();
+
+        token.transfer(address(dao), 100 ether);
+    }
+
+    function testProposeVoteExecute() public {
+        vm.prank(voter);
+        uint256 id = dao.propose(
+            address(token), 0, abi.encodeWithSignature("transfer(address,uint256)", voter, 100 ether), "payout"
+        );
+
+        vm.prank(voter);
+        dao.vote(id, true);
+
+        vm.prank(voter);
+        dao.execute(id);
+
+        assertEq(token.balanceOf(voter), 100 ether);
+    }
+}

--- a/test/AlpyStaking.t.sol
+++ b/test/AlpyStaking.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {AlpyToken} from "../src/AlpyToken.sol";
+import {AlpyStaking} from "../src/AlpyStaking.sol";
+
+contract AlpyStakingTest is Test {
+    AlpyToken token;
+    AlpyStaking staking;
+    address user = address(1);
+
+    function setUp() public {
+        token = new AlpyToken();
+        staking = new AlpyStaking(address(token), address(this), address(this));
+        deal(address(token), user, 1_000 ether);
+    }
+
+    function testStakeExtendWithdraw() public {
+        vm.startPrank(user);
+        token.approve(address(staking), 100 ether);
+        staking.stake(100 ether, 7 days);
+        staking.extendLock(14 days);
+        vm.warp(block.timestamp + 14 days + 1);
+        staking.withdraw();
+        vm.stopPrank();
+        assertEq(token.balanceOf(user), 1_000 ether);
+    }
+}

--- a/test/AlpyToken.t.sol
+++ b/test/AlpyToken.t.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {AlpyToken} from "../src/AlpyToken.sol";
+
+contract AlpyTokenTest is Test {
+    AlpyToken token;
+    address deployer = address(this);
+
+    function setUp() public {
+        token = new AlpyToken();
+    }
+
+    function testInitialSupply() public {
+        assertEq(token.totalSupply(), 10_000_000 ether);
+        assertEq(token.balanceOf(deployer), 10_000_000 ether);
+    }
+}

--- a/test/LendingPool.t.sol
+++ b/test/LendingPool.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {AlpyToken} from "../src/AlpyToken.sol";
+import {LendingPool} from "../src/LendingPool.sol";
+import {MockAggregator} from "./mocks/MockAggregator.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract LendingPoolTest is Test {
+    AlpyToken token;
+    LendingPool pool;
+    address user = address(1);
+
+    function setUp() public {
+        token = new AlpyToken();
+        pool = new LendingPool(address(this));
+        pool.addAsset(address(token), 0, 0, 0, 1e18, 0);
+        MockAggregator agg = new MockAggregator(1e8, 8);
+        pool.setPriceFeed(address(token), agg);
+        deal(address(token), user, 1_000 ether);
+    }
+
+    function testSupplyBorrowRepayWithdraw() public {
+        vm.startPrank(user);
+        token.approve(address(pool), 1_000 ether);
+        pool.supply(token, 1_000 ether);
+        pool.borrow(token, 500 ether);
+        token.approve(address(pool), 500 ether);
+        pool.repay(token, 500 ether, user);
+        pool.withdraw(token, 1_000 ether, user);
+        vm.stopPrank();
+        assertEq(token.balanceOf(user), 1_000 ether);
+    }
+}

--- a/test/RewardDistributor.t.sol
+++ b/test/RewardDistributor.t.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import {AlpyToken} from "../src/AlpyToken.sol";
+import {LendingPool} from "../src/LendingPool.sol";
+import {RewardDistributor} from "../src/RewardDistributor.sol";
+import {MockAggregator} from "./mocks/MockAggregator.sol";
+
+contract RewardDistributorTest is Test {
+    AlpyToken token;
+    LendingPool pool;
+    RewardDistributor distributor;
+    address user = address(1);
+
+    function setUp() public {
+        token = new AlpyToken();
+        pool = new LendingPool(address(this));
+        pool.addAsset(address(token), 0, 0, 0, 1e18, 0);
+        MockAggregator agg = new MockAggregator(1e8, 8);
+        pool.setPriceFeed(address(token), agg);
+        distributor = new RewardDistributor(address(token), address(pool), 1e18);
+        distributor.addRewardToken(address(token));
+        deal(address(token), address(distributor), 1_000 ether);
+        deal(address(token), user, 1_000 ether);
+    }
+
+    function testClaimRewards() public {
+        vm.startPrank(user);
+        token.approve(address(pool), 100 ether);
+        pool.supply(token, 100 ether);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 1 days);
+        distributor.updateIndices();
+
+        vm.prank(user);
+        distributor.claim();
+
+        assertGt(token.balanceOf(user), 900 ether); // earned some rewards
+    }
+}

--- a/test/mocks/MockAggregator.sol
+++ b/test/mocks/MockAggregator.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "lib/chainlink-brownie-contracts/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
+
+contract MockAggregator is AggregatorV3Interface {
+    int256 private _answer;
+    uint8 private _decimals;
+    uint256 private _updatedAt;
+
+    constructor(int256 answer_, uint8 decimals_) {
+        _answer = answer_;
+        _decimals = decimals_;
+        _updatedAt = block.timestamp;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external pure returns (string memory) {
+        return "mock";
+    }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+
+    function latestRoundData() public view returns (uint80, int256, uint256, uint256, uint80) {
+        return (0, _answer, 0, _updatedAt, 0);
+    }
+
+    // Unused functions from interface
+    function getRoundData(uint80) external view returns (uint80, int256, uint256, uint256, uint80) {
+        return latestRoundData();
+    }
+}


### PR DESCRIPTION
## Summary
- expose staking voting power through a `getVotes` helper
- add configurable Foundry scripts for staking, lending, DAO proposals, liquidation, and reward claiming
- introduce comprehensive unit tests covering token, staking, DAO, lending, and rewards

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_688fc7ca0070832e93151661bbc2f8ee